### PR TITLE
fix: robust path handling for get_test_targets.py

### DIFF
--- a/get_test_targets.py
+++ b/get_test_targets.py
@@ -2,11 +2,28 @@
 """
 Extract the builds used in Github CI, so that we can run them locally
 """
+
+from pathlib import Path
+
 import yaml
 
 
-with open('.github/workflows/test-builds.yml') as f:
-    github_configuration = yaml.safe_load(f)
-test_platforms = github_configuration\
-    ['jobs']['test_builds']['strategy']['matrix']['test-platform']
-print(' '.join(test_platforms))
+def main() -> None:
+    """Print the list of PlatformIO environments used for CI builds."""
+
+    workflow = Path(__file__).resolve().parent / ".github" / "workflows" / "test-builds.yml"
+
+    with workflow.open() as f:
+        github_configuration = yaml.safe_load(f)
+
+    jobs = github_configuration.get("jobs", {})
+    test_builds = jobs.get("test_builds", {})
+    strategy = test_builds.get("strategy", {})
+    matrix = strategy.get("matrix", {})
+    test_platforms = matrix.get("test-platform", [])
+
+    print(" ".join(test_platforms))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- make test target script independent of current working directory
- guard against missing keys in workflow definition

## Testing
- `python get_test_targets.py`
- `python -m py_compile get_test_targets.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab8745c0d8832f872b2ce25d844c53